### PR TITLE
UI 수정 사항 반영

### DIFF
--- a/src/main/java/com/yeogi/scms/controller/MainController.java
+++ b/src/main/java/com/yeogi/scms/controller/MainController.java
@@ -348,6 +348,35 @@ public class MainController {
         return "redirect:" + redirectUrl;
     }
 
+//    @PostMapping("/upload")
+//    public String handleFileUpload(@RequestParam("file") MultipartFile[] files,
+//                                   @RequestParam("detailItemCode") String detailItemCode,
+//                                   RedirectAttributes redirectAttributes) {
+//
+//        try {
+//            for (MultipartFile file : files) {
+//                String fileName = evidenceDataService.uploadFile(file, detailItemCode);
+//                redirectAttributes.addFlashAttribute("message", "File uploaded successfully: " + fileName);
+//            }
+//        } catch (IOException e) {
+//            redirectAttributes.addFlashAttribute("message", "Failed to upload file.");
+//        }
+//
+//        // 리다이렉트 URL 결정
+//        String redirectUrl;
+//        if (detailItemCode.startsWith("MNG")) {
+//            redirectUrl = "/manage-system/" + detailItemCode;
+//        } else if (detailItemCode.startsWith("PRT")) {
+//            redirectUrl = "/protect-measures/" + detailItemCode;
+//        } else if (detailItemCode.startsWith("PRC")) {
+//            redirectUrl = "/privacy-require/" + detailItemCode;
+//        } else {
+//            redirectUrl = "/"; // 기본 리다이렉트 URL
+//        }
+//
+//        return "redirect:" + redirectUrl;
+//    }
+
     //Firebase 스토리지에서 파일 조회
 //    @GetMapping("/files/{detailItemCode}")
 //    @ResponseBody

--- a/src/main/java/com/yeogi/scms/controller/MainController.java
+++ b/src/main/java/com/yeogi/scms/controller/MainController.java
@@ -28,6 +28,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -349,6 +350,24 @@ public class MainController {
     }
 
 //    @PostMapping("/upload")
+//    public ResponseEntity<Map<String, Object>> handleFileUpload(@RequestParam("file") MultipartFile[] files,
+//                                                                @RequestParam("detailItemCode") String detailItemCode) {
+//        Map<String, Object> response = new HashMap<>();
+//        try {
+//            for (MultipartFile file : files) {
+//                String fileName = evidenceDataService.uploadFile(file, detailItemCode);
+//                response.put("message", "File uploaded successfully: " + fileName);
+//            }
+//            response.put("success", true);
+//        } catch (IOException e) {
+//            response.put("success", false);
+//            response.put("message", "Failed to upload file.");
+//        }
+//
+//        return ResponseEntity.ok(response);
+//    }
+
+//    @PostMapping("/upload")
 //    public String handleFileUpload(@RequestParam("file") MultipartFile[] files,
 //                                   @RequestParam("detailItemCode") String detailItemCode,
 //                                   RedirectAttributes redirectAttributes) {
@@ -376,6 +395,7 @@ public class MainController {
 //
 //        return "redirect:" + redirectUrl;
 //    }
+
 
     //Firebase 스토리지에서 파일 조회
 //    @GetMapping("/files/{detailItemCode}")

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -242,7 +242,8 @@ a {
 }
 
 .grid-container .section {
-  border: 1px solid black;
+  background-color: #e9dfdf; /* 기본 배경색 */
+  /*border: 1px solid black;*/
   padding: 20px;
   display: flex;
   flex-direction: column; /* 섹션을 수직으로 정렬하기 위해 column으로 설정 */

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -648,7 +648,7 @@ ul {
   padding-left: 0;
 }
 
-td {
+td.padding {
   padding: 10px;
 }
 

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -469,8 +469,8 @@ input[type="checkbox"] {
 }
 
 .chart-container {
-  width: 350px; /* 원하는 가로 크기 */
-  height: 350px; /* 세로 크기 */
+  width: 270px; /* 원하는 가로 크기 */
+  height: 270px; /* 세로 크기 */
   align-items: center;
   justify-content: center; /* 가로로 가운데 정렬 */
   padding: 0 40px;

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -641,4 +641,12 @@ ul {
   padding-left: 0;
 }
 
+td {
+  padding: 10px;
+}
+
+td.no-padding {
+  padding: 0;
+}
+
 

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -360,25 +360,25 @@ input[type="checkbox"] {
   align-items: center;
 }
 
-.contents .upload-box .drag-file {
-  width: 100%;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  border: 3px dashed #dbdbdb;
-}
-.contents .upload-box .drag-file.highlight {
-  border: 3px dashed red;
-}
-.contents .upload-box .drag-file .image {
-  margin-top: 10px;
-  width: 40px;
-}
-.contents .upload-box .drag-file .message {
-  /* margin-bottom: 0; */
-}
+/*.contents .upload-box .drag-file {*/
+/*  width: 100%;*/
+/*  height: 100%;*/
+/*  display: flex;*/
+/*  flex-direction: column;*/
+/*  justify-content: center;*/
+/*  align-items: center;*/
+/*  border: 3px dashed #dbdbdb;*/
+/*}*/
+/*.contents .upload-box .drag-file.highlight {*/
+/*  border: 3px dashed red;*/
+/*}*/
+/*.contents .upload-box .drag-file .image {*/
+/*  margin-top: 10px;*/
+/*  width: 40px;*/
+/*}*/
+/*.contents .upload-box .drag-file .message {*/
+/*  !* margin-bottom: 0; *!*/
+/*}*/
 .contents .upload-box .file-label {
   margin-top: 10px;
   margin-left: auto;

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -620,20 +620,27 @@ input[type="checkbox"] {
   margin-bottom: 0;
 }
 
-.accordion-button[aria-expanded="false"]::after {
-  display: none;
-}
-
-.accordion-button.collapsed::after {
-  display: none;
-}
-
-/* 아코디언 버튼의 기본 상태에서 펼쳐진 스타일 적용 */
 .accordion-button {
-  /* collapsed 상태를 방지하기 위한 기본 설정 */
-  aria-expanded: true;
-  /* 필요시 스타일 추가 */
+  /* 기존에 collapsed 상태를 설정하는 CSS를 제거하고 항상 펼쳐진 상태로 유지 */
+  display: block;
 }
+
+.accordion-collapse {
+  display: block !important;
+}
+
+.accordion-button::after {
+  display: none;
+}
+
+
+/*.accordion-button[aria-expanded="false"]::after {*/
+/*  display: none;*/
+/*}*/
+
+/*.accordion-button.collapsed::after {*/
+/*  display: none;*/
+/*}*/
 
 /* ul이나 li 태그에 대해 list-style-type 속성을 none으로 설정 */
 ul {

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -628,4 +628,17 @@ input[type="checkbox"] {
   display: none;
 }
 
+/* 아코디언 버튼의 기본 상태에서 펼쳐진 스타일 적용 */
+.accordion-button {
+  /* collapsed 상태를 방지하기 위한 기본 설정 */
+  aria-expanded: true;
+  /* 필요시 스타일 추가 */
+}
+
+/* ul이나 li 태그에 대해 list-style-type 속성을 none으로 설정 */
+ul {
+  list-style-type: none;
+  padding-left: 0;
+}
+
 

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -20,7 +20,7 @@ body {
 
   color:rgba(0,0,0,0.87);
   line-height:1.5;
-  overflow-y: auto;
+  overflow-y: hidden;
 }
 
 .mt-5 {

--- a/src/main/resources/static/js/upload.js
+++ b/src/main/resources/static/js/upload.js
@@ -711,7 +711,7 @@ function displayFiles(detailItemCode) {
                         <div class="header">
                             <span class="name">${file.fileName}</span>
                             <span class="size">${formatFileSize(file.fileSize)}</span>
-                            <button class="download-btn" onclick="downloadFile('/download?fileName=${encodedFileName}&detailItemCode=${detailItemCode}&year=${year}', '${file.fileName}')">download</button>
+                            <button class="download-btn" style="border-radius: 5px" onclick="downloadFile('/download?fileName=${encodedFileName}&detailItemCode=${detailItemCode}&year=${year}', '${file.fileName}')">download</button>
 <!--                            <a href="/download?fileName=${file.name}&detailItemCode=${detailItemCode}" download="${encodedFileName}">download</a>-->
 <!--                            <a href="/download?fileName=${file.name}&detailItemCode=${detailItemCode}" download="${file.name}">download</a>-->
 <!--                            <button class="download-btn" onclick="downloadFile('${file.url}')">download</button>-->

--- a/src/main/resources/templates/detail-template.html
+++ b/src/main/resources/templates/detail-template.html
@@ -255,6 +255,7 @@
                             </tr>
                         </table>
                         <button type="submit" id="modal-button-proof" class="modal-button" onclick="handleFormSubmit()">등록하기</button>
+<!--                        <button type="submit" id="modal-button-proof" class="modal-button" onclick="handleFormSubmit(event)">등록하기</button>-->
 <!--                        <button type="submit" id="modal-button-proof" class="modal-button" onclick="uploadFile(dropFile)">등록하기</button>-->
 <!--                        th:each="evidenceData : ${evidenceDatas}"-->
 <!--                        th:attr="data-detail-item-code=${evidenceData.detailItemCode}"-->

--- a/src/main/resources/templates/detail-template.html
+++ b/src/main/resources/templates/detail-template.html
@@ -225,8 +225,8 @@
                                         <div class="contents">
                                             <div class="upload-box">
                                                 <div id="drop-file" class="drag-file">
-                                                    <img src="https://img.icons8.com/pastel-glyph/2x/image-file.png" alt="파일 아이콘" class="image">
-                                                    <p class="message">Drag files to upload</p>
+<!--                                                    <img src="https://img.icons8.com/pastel-glyph/2x/image-file.png" alt="파일 아이콘" class="image">-->
+<!--                                                    <p class="message">Drag files to upload</p>-->
 <!--                                                    <input type="file" class="file" id="dropFile" style="display: none;" multiple onchange="dropFile.handleFiles(this.files)">-->
                                                 </div>
                                                 <label class="file-label" for="chooseFile">파일 선택</label>
@@ -254,7 +254,7 @@
                                 </td>
                             </tr>
                         </table>
-                        <button type="submit" id="modal-button-proof" class="modal-button" onclick="handleFormSubmit()">등록하기</button>
+                        <button type="submit" id="modal-button-proof" class="modal-button" onclick="handleFormSubmit(event)">등록하기</button>
 <!--                        <button type="submit" id="modal-button-proof" class="modal-button" onclick="handleFormSubmit(event)">등록하기</button>-->
 <!--                        <button type="submit" id="modal-button-proof" class="modal-button" onclick="uploadFile(dropFile)">등록하기</button>-->
 <!--                        th:each="evidenceData : ${evidenceDatas}"-->

--- a/src/main/resources/templates/detail-template.html
+++ b/src/main/resources/templates/detail-template.html
@@ -178,7 +178,7 @@
 
             <!-- 섹션 4: 증적자료 -->
             <div class="section" style="grid-column: 1; grid-row: 2; width: 100%; height: 100%; overflow-y: auto;">
-                <div style="display: flex; align-items: center;">
+                <div style="display: flex; align-items: center; margin-bottom: 10px;">
                     <h2>증적자료</h2>
                     <button type="button" class="default-button btn-primary d-block ml-auto" style="margin-left: auto;" onclick="openModal('editModal-proof', this.id)" th:value="${detailItemCode}">수정</button>
                     <input type="hidden" name="detailItemCode" th:value="${detailItemCode}">

--- a/src/main/resources/templates/detail-template.html
+++ b/src/main/resources/templates/detail-template.html
@@ -81,23 +81,23 @@
                         <table class="modal-table">
                             <tr style="height: 10%">
                                 <th style="width: 20%; text-align: center;"><label for="modificationDate1">일시</label></th>
-                                <td class="no-padding"><input type="text" id="modificationDate1" style="width: 100%; height: 100%" readonly></td>
+                                <td><input type="text" id="modificationDate1" style="width: 100%; height: 100%" readonly></td>
                             </tr>
                             <tr style="height: 10%">
                                 <th style="width: 20%; text-align: center;"><label for="modifier1">변경자</label></th>
-                                <td class="no-padding"><input type="text" id="modifier1" style="width: 100%; height: 100%" readonly></td>
+                                <td><input type="text" id="modifier1" style="width: 100%; height: 100%" readonly></td>
                             </tr>
                             <tr style="height: 30%">
                                 <th style="width: 20%; text-align: center;"><label for="certificationStandard">인증기준</label></th>
-                                <td  class="no-padding" colspan="2"><textarea id="certificationStandard" name="certificationStandard" style="width: 100%; height: 100%" required></textarea></td>
+                                <td colspan="2"><textarea id="certificationStandard" name="certificationStandard" style="width: 100%; height: 100%" required></textarea></td>
                             </tr>
                             <tr style="height: 40%">
                                 <th style="width: 20%; text-align: center;"><label for="majorPoints">주요 확인사항</label></th>
-                                <td  class="no-padding" colspan="2"><textarea id="majorPoints" name="majorPoints" style="width: 100%; height: 100%" required></textarea></td>
+                                <td colspan="2"><textarea id="majorPoints" name="majorPoints" style="width: 100%; height: 100%" required></textarea></td>
                             </tr>
                             <tr style="height: 10%">
                                 <th style="width: 20%; text-align: center;"><label for="relatedLaws">관련 법규</label></th>
-                                <td  class="no-padding" colspan="2"><textarea id="relatedLaws" name="relatedLaws" style="width: 100%; height: 100%" required></textarea></td>
+                                <td colspan="2"><textarea id="relatedLaws" name="relatedLaws" style="width: 100%; height: 100%" required></textarea></td>
                             </tr>
                         </table>
 
@@ -150,23 +150,23 @@
                         <table class="modal-table">
                             <tr style="height: 10%">
                                 <th style="width: 20%; text-align: center;"><label for="modificationDate2">일시</label></th>
-                                <td class="no-padding"><input type="text" id="modificationDate2" style="width: 100%; height: 100%" readonly></td>
+                                <td><input type="text" id="modificationDate2" style="width: 100%; height: 100%" readonly></td>
                             </tr>
                             <tr style="height: 10%">
                                 <th style="width: 20%; text-align: center;"><label for="modifier2">변경자</label></th>
-                                <td class="no-padding"><input type="text" id="modifier2" style="width: 100%; height: 100%" readonly></td>
+                                <td><input type="text" id="modifier2" style="width: 100%; height: 100%" readonly></td>
                             </tr>
                             <tr style="height: 60%">
                                 <th style="width: 20%; text-align: center;"><label for="currentSituation">현황</label></th>
-                                <td class="no-padding" colspan="2"><textarea id="currentSituation" name="currentSituation" style="width: 100%; height: 100%" required></textarea></td>
+                                <td colspan="2"><textarea id="currentSituation" name="currentSituation" style="width: 100%; height: 100%" required></textarea></td>
                             </tr>
                             <tr style="height: 10%">
                                 <th style="width: 20%; text-align: center;"><label for="documentName">문서명</label></th>
-                                <td class="no-padding" colspan="2"><textarea id="documentName" name="documentName" style="width: 100%; height: 100%" required></textarea></td>
+                                <td colspan="2"><textarea id="documentName" name="documentName" style="width: 100%; height: 100%" required></textarea></td>
                             </tr>
                             <tr style="height: 10%">
                                 <th style="width: 20%; text-align: center;"><label for="evidenceName">증적명</label></th>
-                                <td class="no-padding" colspan="2"><textarea id="evidenceName" name="evidenceName" style="width: 100%; height: 100%" required></textarea></td>
+                                <td colspan="2"><textarea id="evidenceName" name="evidenceName" style="width: 100%; height: 100%" required></textarea></td>
                             </tr>
                         </table>
                         <button type="button" id="modal-button-operational" onclick="saveChangesOperational(this)" class="modal-button"
@@ -211,15 +211,15 @@
                         <table class="modal-table">
                             <tr style="height: 10%">
                                 <th style="width: 20%; text-align: center;"><label for="modificationDate3">일시</label></th>
-                                <td class="no-padding"><input type="text" id="modificationDate3" style="width: 100%; height: 100%" readonly></td>
+                                <td><input type="text" id="modificationDate3" style="width: 100%; height: 100%" readonly></td>
                             </tr>
                             <tr style="height: 10%">
                                 <th style="width: 20%; text-align: center;"><label for="modifier3">변경자</label></th>
-                                <td class="no-padding"><input type="text" id="modifier3" style="width: 100%; height: 100%" readonly></td>
+                                <td><input type="text" id="modifier3" style="width: 100%; height: 100%" readonly></td>
                             </tr>
                             <tr style="height: 80%">
 <!--                                <th style="width: 20%; text-align: right;"><label for="drop-file">파일 선택</label></th>-->
-                                <td class="no-padding" colspan="2">
+                                <td colspan="2">
 
                                     <div id="root">
                                         <div class="contents">
@@ -322,15 +322,15 @@
                         <table class="modal-table">
                             <tr style="height: 10%">
                                 <th style="width: 20%; text-align: center;"><label for="modificationDate4">일시</label></th>
-                                <td class="no-padding"><input type="text" id="modificationDate4" style="width: 100%; height: 100%" readonly></td>
+                                <td><input type="text" id="modificationDate4" style="width: 100%; height: 100%" readonly></td>
                             </tr>
                             <tr style="height: 10%">
                                 <th style="width: 20%; text-align: center;"><label for="modifier4">변경자</label></th>
-                                <td class="no-padding"><input type="text" id="modifier4" style="width: 100%; height: 100%" readonly></td>
+                                <td><input type="text" id="modifier4" style="width: 100%; height: 100%" readonly></td>
                             </tr>
                             <tr style="height: 10%">
                                 <th style="width: 20%; text-align: center;"><label for="certificationType">인증 구분</label></th>
-                                <td class="no-padding">
+                                <td>
                                     <select id="certificationType" name="certificationType" style="width: 100%; height: 100%">
                                         <option value="ISMS-P">ISMS-P</option>
                                         <option value="ISO 27K">ISO 27K</option>
@@ -341,7 +341,7 @@
                             </tr>
                             <tr style="height: 80%">
                                 <th style="width: 20%; text-align: center;"><label for="defectContent">결함 내용</label></th>
-                                <td class="no-padding" colspan="2">
+                                <td colspan="2">
                                     <textarea id="defectContent" name="defectContent" style="width: 100%; height: 100%" required></textarea>
                                     <input type="hidden" data-certification="ISMS-P" value="${defectManage.ismsP}">
                                     <input type="hidden" data-certification="ISO 27K" value="${defectManage.iso27k}">

--- a/src/main/resources/templates/detail-template.html
+++ b/src/main/resources/templates/detail-template.html
@@ -80,23 +80,23 @@
                         <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
                         <table class="modal-table">
                             <tr style="height: 10%">
-                                <th style="width: 20%; text-align: right;"><label for="modificationDate1">일시</label></th>
+                                <th style="width: 20%; text-align: center;"><label for="modificationDate1">일시</label></th>
                                 <td><input type="text" id="modificationDate1" style="width: 100%; height: 100%" readonly></td>
                             </tr>
                             <tr style="height: 10%">
-                                <th style="width: 20%; text-align: right;"><label for="modifier1">변경자</label></th>
+                                <th style="width: 20%; text-align: center;"><label for="modifier1">변경자</label></th>
                                 <td><input type="text" id="modifier1" style="width: 100%; height: 100%" readonly></td>
                             </tr>
                             <tr style="height: 30%">
-                                <th style="width: 20%; text-align: right;"><label for="certificationStandard">인증기준</label></th>
+                                <th style="width: 20%; text-align: center;"><label for="certificationStandard">인증기준</label></th>
                                 <td colspan="2"><textarea id="certificationStandard" name="certificationStandard" style="width: 100%; height: 100%" required></textarea></td>
                             </tr>
                             <tr style="height: 40%">
-                                <th style="width: 20%; text-align: right;"><label for="majorPoints">주요 확인사항</label></th>
+                                <th style="width: 20%; text-align: center;"><label for="majorPoints">주요 확인사항</label></th>
                                 <td colspan="2"><textarea id="majorPoints" name="majorPoints" style="width: 100%; height: 100%" required></textarea></td>
                             </tr>
                             <tr style="height: 10%">
-                                <th style="width: 20%; text-align: right;"><label for="relatedLaws">관련 법규</label></th>
+                                <th style="width: 20%; text-align: center;"><label for="relatedLaws">관련 법규</label></th>
                                 <td colspan="2"><textarea id="relatedLaws" name="relatedLaws" style="width: 100%; height: 100%" required></textarea></td>
                             </tr>
                         </table>
@@ -149,23 +149,23 @@
                         <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/> <!-- CSRF 토큰 추가 -->
                         <table class="modal-table">
                             <tr style="height: 10%">
-                                <th style="width: 20%; text-align: right;"><label for="modificationDate2">일시</label></th>
+                                <th style="width: 20%; text-align: center;"><label for="modificationDate2">일시</label></th>
                                 <td><input type="text" id="modificationDate2" style="width: 100%; height: 100%" readonly></td>
                             </tr>
                             <tr style="height: 10%">
-                                <th style="width: 20%; text-align: right;"><label for="modifier2">변경자</label></th>
+                                <th style="width: 20%; text-align: center;"><label for="modifier2">변경자</label></th>
                                 <td><input type="text" id="modifier2" style="width: 100%; height: 100%" readonly></td>
                             </tr>
                             <tr style="height: 60%">
-                                <th style="width: 20%; text-align: right;"><label for="currentSituation">현황</label></th>
+                                <th style="width: 20%; text-align: center;"><label for="currentSituation">현황</label></th>
                                 <td colspan="2"><textarea id="currentSituation" name="currentSituation" style="width: 100%; height: 100%" required></textarea></td>
                             </tr>
                             <tr style="height: 10%">
-                                <th style="width: 20%; text-align: right;"><label for="documentName">문서명</label></th>
+                                <th style="width: 20%; text-align: center;"><label for="documentName">문서명</label></th>
                                 <td colspan="2"><textarea id="documentName" name="documentName" style="width: 100%; height: 100%" required></textarea></td>
                             </tr>
                             <tr style="height: 10%">
-                                <th style="width: 20%; text-align: right;"><label for="evidenceName">증적명</label></th>
+                                <th style="width: 20%; text-align: center;"><label for="evidenceName">증적명</label></th>
                                 <td colspan="2"><textarea id="evidenceName" name="evidenceName" style="width: 100%; height: 100%" required></textarea></td>
                             </tr>
                         </table>
@@ -210,11 +210,11 @@
                         <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/> <!-- CSRF 토큰 추가 -->
                         <table class="modal-table">
                             <tr style="height: 10%">
-                                <th style="width: 20%; text-align: right;"><label for="modificationDate3">일시</label></th>
+                                <th style="width: 20%; text-align: center;"><label for="modificationDate3">일시</label></th>
                                 <td><input type="text" id="modificationDate3" style="width: 100%; height: 100%" readonly></td>
                             </tr>
                             <tr style="height: 10%">
-                                <th style="width: 20%; text-align: right;"><label for="modifier3">변경자</label></th>
+                                <th style="width: 20%; text-align: center;"><label for="modifier3">변경자</label></th>
                                 <td><input type="text" id="modifier3" style="width: 100%; height: 100%" readonly></td>
                             </tr>
                             <tr style="height: 80%">
@@ -321,15 +321,15 @@
                         <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/> <!-- CSRF 토큰 추가 -->
                         <table class="modal-table">
                             <tr style="height: 10%">
-                                <th style="width: 20%; text-align: right;"><label for="modificationDate4">일시</label></th>
+                                <th style="width: 20%; text-align: center;"><label for="modificationDate4">일시</label></th>
                                 <td><input type="text" id="modificationDate4" style="width: 100%; height: 100%" readonly></td>
                             </tr>
                             <tr style="height: 10%">
-                                <th style="width: 20%; text-align: right;"><label for="modifier4">변경자</label></th>
+                                <th style="width: 20%; text-align: center;"><label for="modifier4">변경자</label></th>
                                 <td><input type="text" id="modifier4" style="width: 100%; height: 100%" readonly></td>
                             </tr>
                             <tr style="height: 10%">
-                                <th style="width: 20%; text-align: right;"><label for="certificationType">인증 구분</label></th>
+                                <th style="width: 20%; text-align: center;"><label for="certificationType">인증 구분</label></th>
                                 <td>
                                     <select id="certificationType" name="certificationType" style="width: 100%; height: 100%">
                                         <option value="ISMS-P">ISMS-P</option>
@@ -340,7 +340,7 @@
                                 </td>
                             </tr>
                             <tr style="height: 80%">
-                                <th style="width: 20%; text-align: right;"><label for="defectContent">결함 내용</label></th>
+                                <th style="width: 20%; text-align: center;"><label for="defectContent">결함 내용</label></th>
                                 <td colspan="2">
                                     <textarea id="defectContent" name="defectContent" style="width: 100%; height: 100%" required></textarea>
                                     <input type="hidden" data-certification="ISMS-P" value="${defectManage.ismsP}">

--- a/src/main/resources/templates/detail-template.html
+++ b/src/main/resources/templates/detail-template.html
@@ -22,7 +22,7 @@
 
 <main class="d-flex flex-nowrap">
     <div th:replace="fragments/sidebar :: sidebar"></div>
-    <div class="content p-4 main-contents">
+    <div class="content p-4 main-contents" style="overflow-y: scroll">
         <input type="hidden" id="detailItemCode" name="detailItemCode" th:value="${detailItemCode}">
         <p class="table_name" style="display: flex; align-items: center; margin-right: auto;" th:text="${detailItemTypeName}"> 세부 항목 이름</p>
         <div style="display: flex; align-items: center; margin-left: auto;">

--- a/src/main/resources/templates/detail-template.html
+++ b/src/main/resources/templates/detail-template.html
@@ -81,23 +81,23 @@
                         <table class="modal-table">
                             <tr style="height: 10%">
                                 <th style="width: 20%; text-align: center;"><label for="modificationDate1">일시</label></th>
-                                <td><input type="text" id="modificationDate1" style="width: 100%; height: 100%" readonly></td>
+                                <td class="no-padding"><input type="text" id="modificationDate1" style="width: 100%; height: 100%" readonly></td>
                             </tr>
                             <tr style="height: 10%">
                                 <th style="width: 20%; text-align: center;"><label for="modifier1">변경자</label></th>
-                                <td><input type="text" id="modifier1" style="width: 100%; height: 100%" readonly></td>
+                                <td class="no-padding"><input type="text" id="modifier1" style="width: 100%; height: 100%" readonly></td>
                             </tr>
                             <tr style="height: 30%">
                                 <th style="width: 20%; text-align: center;"><label for="certificationStandard">인증기준</label></th>
-                                <td colspan="2"><textarea id="certificationStandard" name="certificationStandard" style="width: 100%; height: 100%" required></textarea></td>
+                                <td  class="no-padding" colspan="2"><textarea id="certificationStandard" name="certificationStandard" style="width: 100%; height: 100%" required></textarea></td>
                             </tr>
                             <tr style="height: 40%">
                                 <th style="width: 20%; text-align: center;"><label for="majorPoints">주요 확인사항</label></th>
-                                <td colspan="2"><textarea id="majorPoints" name="majorPoints" style="width: 100%; height: 100%" required></textarea></td>
+                                <td  class="no-padding" colspan="2"><textarea id="majorPoints" name="majorPoints" style="width: 100%; height: 100%" required></textarea></td>
                             </tr>
                             <tr style="height: 10%">
                                 <th style="width: 20%; text-align: center;"><label for="relatedLaws">관련 법규</label></th>
-                                <td colspan="2"><textarea id="relatedLaws" name="relatedLaws" style="width: 100%; height: 100%" required></textarea></td>
+                                <td  class="no-padding" colspan="2"><textarea id="relatedLaws" name="relatedLaws" style="width: 100%; height: 100%" required></textarea></td>
                             </tr>
                         </table>
 
@@ -150,23 +150,23 @@
                         <table class="modal-table">
                             <tr style="height: 10%">
                                 <th style="width: 20%; text-align: center;"><label for="modificationDate2">일시</label></th>
-                                <td><input type="text" id="modificationDate2" style="width: 100%; height: 100%" readonly></td>
+                                <td class="no-padding"><input type="text" id="modificationDate2" style="width: 100%; height: 100%" readonly></td>
                             </tr>
                             <tr style="height: 10%">
                                 <th style="width: 20%; text-align: center;"><label for="modifier2">변경자</label></th>
-                                <td><input type="text" id="modifier2" style="width: 100%; height: 100%" readonly></td>
+                                <td class="no-padding"><input type="text" id="modifier2" style="width: 100%; height: 100%" readonly></td>
                             </tr>
                             <tr style="height: 60%">
                                 <th style="width: 20%; text-align: center;"><label for="currentSituation">현황</label></th>
-                                <td colspan="2"><textarea id="currentSituation" name="currentSituation" style="width: 100%; height: 100%" required></textarea></td>
+                                <td class="no-padding" colspan="2"><textarea id="currentSituation" name="currentSituation" style="width: 100%; height: 100%" required></textarea></td>
                             </tr>
                             <tr style="height: 10%">
                                 <th style="width: 20%; text-align: center;"><label for="documentName">문서명</label></th>
-                                <td colspan="2"><textarea id="documentName" name="documentName" style="width: 100%; height: 100%" required></textarea></td>
+                                <td class="no-padding" colspan="2"><textarea id="documentName" name="documentName" style="width: 100%; height: 100%" required></textarea></td>
                             </tr>
                             <tr style="height: 10%">
                                 <th style="width: 20%; text-align: center;"><label for="evidenceName">증적명</label></th>
-                                <td colspan="2"><textarea id="evidenceName" name="evidenceName" style="width: 100%; height: 100%" required></textarea></td>
+                                <td class="no-padding" colspan="2"><textarea id="evidenceName" name="evidenceName" style="width: 100%; height: 100%" required></textarea></td>
                             </tr>
                         </table>
                         <button type="button" id="modal-button-operational" onclick="saveChangesOperational(this)" class="modal-button"
@@ -211,15 +211,15 @@
                         <table class="modal-table">
                             <tr style="height: 10%">
                                 <th style="width: 20%; text-align: center;"><label for="modificationDate3">일시</label></th>
-                                <td><input type="text" id="modificationDate3" style="width: 100%; height: 100%" readonly></td>
+                                <td class="no-padding"><input type="text" id="modificationDate3" style="width: 100%; height: 100%" readonly></td>
                             </tr>
                             <tr style="height: 10%">
                                 <th style="width: 20%; text-align: center;"><label for="modifier3">변경자</label></th>
-                                <td><input type="text" id="modifier3" style="width: 100%; height: 100%" readonly></td>
+                                <td class="no-padding"><input type="text" id="modifier3" style="width: 100%; height: 100%" readonly></td>
                             </tr>
                             <tr style="height: 80%">
 <!--                                <th style="width: 20%; text-align: right;"><label for="drop-file">파일 선택</label></th>-->
-                                <td colspan="2">
+                                <td class="no-padding" colspan="2">
 
                                     <div id="root">
                                         <div class="contents">
@@ -322,15 +322,15 @@
                         <table class="modal-table">
                             <tr style="height: 10%">
                                 <th style="width: 20%; text-align: center;"><label for="modificationDate4">일시</label></th>
-                                <td><input type="text" id="modificationDate4" style="width: 100%; height: 100%" readonly></td>
+                                <td class="no-padding"><input type="text" id="modificationDate4" style="width: 100%; height: 100%" readonly></td>
                             </tr>
                             <tr style="height: 10%">
                                 <th style="width: 20%; text-align: center;"><label for="modifier4">변경자</label></th>
-                                <td><input type="text" id="modifier4" style="width: 100%; height: 100%" readonly></td>
+                                <td class="no-padding"><input type="text" id="modifier4" style="width: 100%; height: 100%" readonly></td>
                             </tr>
                             <tr style="height: 10%">
                                 <th style="width: 20%; text-align: center;"><label for="certificationType">인증 구분</label></th>
-                                <td>
+                                <td class="no-padding">
                                     <select id="certificationType" name="certificationType" style="width: 100%; height: 100%">
                                         <option value="ISMS-P">ISMS-P</option>
                                         <option value="ISO 27K">ISO 27K</option>
@@ -341,7 +341,7 @@
                             </tr>
                             <tr style="height: 80%">
                                 <th style="width: 20%; text-align: center;"><label for="defectContent">결함 내용</label></th>
-                                <td colspan="2">
+                                <td class="no-padding" colspan="2">
                                     <textarea id="defectContent" name="defectContent" style="width: 100%; height: 100%" required></textarea>
                                     <input type="hidden" data-certification="ISMS-P" value="${defectManage.ismsP}">
                                     <input type="hidden" data-certification="ISO 27K" value="${defectManage.iso27k}">

--- a/src/main/resources/templates/logManage.html
+++ b/src/main/resources/templates/logManage.html
@@ -26,6 +26,32 @@
             color: lightgray;
             pointer-events: none;
         }
+
+        /* 가운데 정렬 스타일 추가 */
+        .center-align {
+            text-align: center;
+        }
+
+        /* 표 열 너비 조정 */
+        .col-no {
+            width: 10%; /* NO 열의 너비 */
+        }
+
+        .col-act {
+            width: 10%; /* ACT 열의 너비 */
+        }
+
+        .col-user {
+            width: 30%; /* 접속자 열의 너비 */
+        }
+
+        .col-path {
+            width: 30%; /* PATH 열의 너비 */
+        }
+
+        .col-timestamp {
+            width: 20%; /* 접속시간 열의 너비 */
+        }
     </style>
 
 </head>
@@ -39,20 +65,20 @@
         <table style="width:100%">
             <thead>
             <tr>
-                <th class="col-1" scope="col" style="height: 50px;">NO</th>
-                <th class="col-1" scope="col" style="height: 50px;">접속자</th>
-                <th class="col-1" scope="col" style="height: 50px;">ACT</th>
-                <th class="col-1" scope="col" style="height: 50px;">PATH</th>
-                <th class="col-1" scope="col" style="height: 50px;">접속시간</th>
+                <th class="col-no col-1" scope="col" style="height: 50px;">NO</th>
+                <th class="col-user col-1" scope="col" style="height: 50px;">접속자</th>
+                <th class="col-act col-1" scope="col" style="height: 50px;">ACT</th>
+                <th class="col-path col-1" scope="col" style="height: 50px;">PATH</th>
+                <th class="col-timestamp col-1" scope="col" style="height: 50px;">접속시간</th>
             </tr>
             </thead>
             <tbody>
             <tr th:each="log, iterStat : ${logs}">
-                <td style="height: 50px;" th:text="${log.logSequence}"></td>
-                <td th:text="${log.accessId}"></td>
-                <td th:text="${log.action}"></td>
-                <td th:text="${log.accessPath}"></td>
-                <td th:text="${log.timestamp}"></td>
+                <td class="col-no center-align" style="height: 50px;" th:text="${log.logSequence}"></td>
+                <td class="col-user center-align" th:text="${log.accessId}"></td>
+                <td class="col-act center-align" th:text="${log.action}"></td>
+                <td class="col-path" th:text="${log.accessPath}"></td>
+                <td class="col-timestamp center-align" th:text="${log.timestamp}"></td>
             </tr>
             </tbody>
         </table>

--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -336,7 +336,7 @@
 
     <div style="display: flex; flex-wrap: wrap; justify-content: space-between; max-width: 100%;">
       <!-- 첫 번째 도넛 그래프 -->
-      <div class="chart-container" style="flex-basis: calc(33.33% - 20px); margin-bottom: 20px;">
+      <div class="chart-container" style="flex-basis: calc(33.33% - 5px); margin-bottom: 20px;">
         <canvas id="manageChart"></canvas>
         <div class="progress-info">
           <div class="progress-title" style="font-size: 12px;">진행현황</div>
@@ -346,7 +346,7 @@
       </div>
 
       <!-- 두 번째 도넛 그래프 (보호대책 요구사항) -->
-      <div class="chart-container" style="flex-basis: calc(33.33% - 20px); margin-bottom: 20px;">
+      <div class="chart-container" style="flex-basis: calc(33.33% - 5px); margin-bottom: 20px;">
         <canvas id="protectChart"></canvas>
         <div class="progress-info">
           <div class="progress-title" style="font-size: 12px;">진행현황</div>
@@ -356,7 +356,7 @@
       </div>
 
       <!-- 세 번째 도넛 그래프 (개인정보 처리단계별 요구사항) -->
-      <div class="chart-container" style="flex-basis: calc(33.33% - 20px); margin-bottom: 20px;">
+      <div class="chart-container" style="flex-basis: calc(33.33% - 5px); margin-bottom: 20px;">
         <canvas id="privacyChart"></canvas>
         <div class="progress-info">
           <div class="progress-title" style="font-size: 12px;">진행현황</div>
@@ -366,7 +366,7 @@
       </div>
 
       <!-- 선 그래프 -->
-      <div class="line-chart-container chart-container" style="flex-basis: 100%; margin-top: 50px;">
+      <div class="line-chart-container chart-container" style="flex-basis: 100%; margin-top: 30px;">
         <canvas id="monthlyProgressChart"></canvas> <!-- Monthly Progress Chart ID -->
       </div>
 

--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -336,7 +336,7 @@
 
     <div style="display: flex; flex-wrap: wrap; justify-content: space-between; max-width: 100%;">
       <!-- 첫 번째 도넛 그래프 -->
-      <div class="chart-container" style="flex-basis: calc(33.33% - 5px); margin-bottom: 20px;">
+      <div class="chart-container" style="flex-basis: calc(33.33% - 1px); margin-bottom: 20px;">
         <canvas id="manageChart"></canvas>
         <div class="progress-info">
           <div class="progress-title" style="font-size: 12px;">진행현황</div>
@@ -346,7 +346,7 @@
       </div>
 
       <!-- 두 번째 도넛 그래프 (보호대책 요구사항) -->
-      <div class="chart-container" style="flex-basis: calc(33.33% - 5px); margin-bottom: 20px;">
+      <div class="chart-container" style="flex-basis: calc(33.33% - 1px); margin-bottom: 20px;">
         <canvas id="protectChart"></canvas>
         <div class="progress-info">
           <div class="progress-title" style="font-size: 12px;">진행현황</div>
@@ -356,7 +356,7 @@
       </div>
 
       <!-- 세 번째 도넛 그래프 (개인정보 처리단계별 요구사항) -->
-      <div class="chart-container" style="flex-basis: calc(33.33% - 5px); margin-bottom: 20px;">
+      <div class="chart-container" style="flex-basis: calc(33.33% - 1px); margin-bottom: 20px;">
         <canvas id="privacyChart"></canvas>
         <div class="progress-info">
           <div class="progress-title" style="font-size: 12px;">진행현황</div>

--- a/src/main/resources/templates/manageSystem.html
+++ b/src/main/resources/templates/manageSystem.html
@@ -33,19 +33,19 @@
                 <th class="col-1">PCI-DSS</th>
             </tr>
             <tr th:each="scmMaster : ${scmMasters}">
-                <td th:text="${scmMaster.certificationTypeName}" style="height: 200px;"></td>
-                <td style="height: 200px;">
+                <td class="padding" th:text="${scmMaster.certificationTypeName}" style="height: 200px;"></td>
+                <td class="padding" style="height: 200px;">
                     <ul>
                         <li th:each="detail : ${certifDetails[scmMaster.documentCode]}">
                             <a th:href="@{'/manage-system/' + ${detail.detailItemCode}}" th:text="${detail.detailItemTypeName}"></a>
                         </li>
                     </ul>
                 </td>
-                <td style="height: 200px;">
+                <td class="padding" style="height: 200px;">
                     <div th:text="${scmMaster.isoDetails}" th:attr="id='isoDetailsDiv-'+${scmMaster.documentCode}"></div>
                     <textarea class="full-width hidden" th:attr="id='isoDetailsTextarea-'+${scmMaster.documentCode}"></textarea>
                 </td>
-                <td style="height: 200px;">
+                <td class="padding" style="height: 200px;">
                     <div th:text="${scmMaster.pciDssDetails}" th:attr="id='pciDssDiv-'+${scmMaster.documentCode}"></div>
                     <textarea class="full-width hidden" th:attr="id='pciDssTextarea-'+${scmMaster.documentCode}"></textarea>
                 </td>

--- a/src/main/resources/templates/manageSystem.html
+++ b/src/main/resources/templates/manageSystem.html
@@ -26,7 +26,7 @@
                 <th class="col-1" rowspan="2">구분</th>
                 <th class="col-1" rowspan="2">세부항목</th>
                 <th class="col-1" colspan="2">심사구분</th>
-                <th class="col-1" rowspan="2"></th>
+                <th class="col-1" rowspan="2">수정/확인</th>
             </tr>
             <tr>
                 <th class="col-1">ISO 27001/27017/27018/27701</th>

--- a/src/main/resources/templates/privacyRequire.html
+++ b/src/main/resources/templates/privacyRequire.html
@@ -27,7 +27,7 @@
                 <th class="col-1" rowspan="2">구분</th>
                 <th class="col-1" rowspan="2">세부항목</th>
                 <th class="col-1" colspan="2">심사구분</th>
-                <th class="col-1" rowspan="2"></th>
+                <th class="col-1" rowspan="2">수정/확인</th>
             </tr>
             <tr>
                 <th class="col-1">ISO 27001/27017/27018/27701</th>

--- a/src/main/resources/templates/privacyRequire.html
+++ b/src/main/resources/templates/privacyRequire.html
@@ -34,19 +34,19 @@
                 <th class="col-1">PCI-DSS</th>
             </tr>
             <tr th:each="scmMaster : ${scmMasters}">
-                <td th:text="${scmMaster.certificationTypeName}" style="height: 200px;"></td>
-                <td style="height: 200px;">
+                <td class="padding" th:text="${scmMaster.certificationTypeName}" style="height: 200px;"></td>
+                <td class="padding" style="height: 200px;">
                     <ul>
                         <li th:each="detail : ${certifDetails[scmMaster.documentCode]}">
                             <a th:href="@{'/privacy-require/' + ${detail.detailItemCode}}" th:text="${detail.detailItemTypeName}"></a>
                         </li>
                     </ul>
                 </td>
-                <td style="height: 200px;">
+                <td class="padding" style="height: 200px;">
                     <div th:text="${scmMaster.isoDetails}" th:attr="id='isoDetailsDiv-'+${scmMaster.documentCode}"></div>
                     <textarea class="full-width hidden" th:attr="id='isoDetailsTextarea-'+${scmMaster.documentCode}"></textarea>
                 </td>
-                <td style="height: 200px;">
+                <td class="padding" style="height: 200px;">
                     <div th:text="${scmMaster.pciDssDetails}" th:attr="id='pciDssDiv-'+${scmMaster.documentCode}"></div>
                     <textarea class="full-width hidden" th:attr="id='pciDssTextarea-'+${scmMaster.documentCode}"></textarea>
                 </td>

--- a/src/main/resources/templates/protectMeasures.html
+++ b/src/main/resources/templates/protectMeasures.html
@@ -27,7 +27,7 @@
                 <th class="col-1" rowspan="2">구분</th>
                 <th class="col-1" rowspan="2">세부항목</th>
                 <th class="col-1" colspan="2">심사구분</th>
-                <th class="col-1" rowspan="2"></th>
+                <th class="col-1" rowspan="2">수정/확인</th>
             </tr>
             <tr>
                 <th class="col-1" >ISO 27001/27017/27018/27701</th>

--- a/src/main/resources/templates/protectMeasures.html
+++ b/src/main/resources/templates/protectMeasures.html
@@ -34,19 +34,19 @@
                 <th class="col-1" >PCI-DSS</th>
             </tr>
             <tr th:each="scmMaster : ${scmMasters}">
-                <td th:text="${scmMaster.certificationTypeName}" style="height: 200px;"></td>
-                <td style="height: 200px;">
+                <td class="padding" th:text="${scmMaster.certificationTypeName}" style="height: 200px;"></td>
+                <td class="padding" style="height: 200px;">
                     <ul>
                         <li th:each="detail : ${certifDetails[scmMaster.documentCode]}">
                             <a th:href="@{'/protect-measures/' + ${detail.detailItemCode}}" th:text="${detail.detailItemTypeName}"></a>
                         </li>
                     </ul>
                 </td>
-                <td style="height: 200px;">
+                <td class="padding" style="height: 200px;">
                     <div th:text="${scmMaster.isoDetails}" th:attr="id='isoDetailsDiv-'+${scmMaster.documentCode}"></div>
                     <textarea class="full-width hidden" th:attr="id='isoDetailsTextarea-'+${scmMaster.documentCode}"></textarea>
                 </td>
-                <td style="height: 200px;">
+                <td class="padding" style="height: 200px;">
                     <div th:text="${scmMaster.pciDssDetails}" th:attr="id='pciDssDiv-'+${scmMaster.documentCode}"></div>
                     <textarea class="full-width hidden" th:attr="id='pciDssTextarea-'+${scmMaster.documentCode}"></textarea>
                 </td>


### PR DESCRIPTION
1. 증적자료 드래그앤드롭 기능 삭제
2. 파일 업로드, 다운로드 - js에서 서버로 데이터 전송하기전에 특정 확장자가 아니면 리퀘스트 날릴 수 없도록 수정 (fetch 이전)
3. UI 수정 사항
    1. Main 화면 월간 증적률 표 사이즈를 줄여서 스크롤 하지 않아도 한 눈에 들어오도록 (도넛, 표를 모두 줄이는 것이 베스트, 안되면 표만 줄이기)
    2. 보안인증관리 탭 페이지에 수정/확인 구분 추가
    3. 보안인증관리 탭 페이지에 소항목 글머리 기호 삭제 (안해도 됨)
    4. 보안인증관리 탭 페이지의 표 안에 패딩을 주어서 글자 앞에 여백 설정
    5. 보안인증관리 탭 아코디언 항상 펼쳐지도록
    6. 세부 항목 페이지 border 라인 제거 후 배경색을 다르게 해서 영역 구분
    7. 세부 항목 페이지 일시, 변경자 가운데 정렬
    8. 접속 로그 NO나 ACT 표 가로 너비를 조금만 줄이고, PATH, 접속자 길게
    9. 접속 로그 PATH 빼고 다 가운데 정렬